### PR TITLE
[jIicho] - 자동 롤링 영역 구현 시작

### DIFF
--- a/src/components/rollingArea/RollingArea.jsx
+++ b/src/components/rollingArea/RollingArea.jsx
@@ -11,9 +11,6 @@ const RollingBox = styled.div`
   width: 461px;
   height: 49px;
   background-color: var(--surface-alt);
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
   border: 1px solid var(--border-default);
   box-sizing: border-box;
   overflow: hidden;
@@ -43,16 +40,22 @@ const PressNewsTitle = styled.div`
   }
 `;
 
-export default function RollingArea() {
-  const newsList = [
-    { press: "연합뉴스", title: "[1보] 김기현·안철수 본경선 진출" },
-    { press: "중앙일보", title: "[속보] 삼성전자 1분기 실적 발표" },
-    { press: "한겨레", title: "서울시, 청년 월세 지원 대상 확대" },
-    { press: "조선일보", title: "美 반도체 법안 통과…한국 영향은?" },
-    { press: "경향신문", title: "기후변화로 여름 더 길어졌다" },
-  ];
+const newsList = [
+  { press: "연합뉴스", title: "[1보] 김기현·안철수 본경선 진출" },
+  { press: "중앙일보", title: "[속보] 삼성전자 1분기 실적 발표" },
+  { press: "한겨레", title: "서울시, 청년 월세 지원 대상 확대" },
+  { press: "조선일보", title: "美 반도체 법안 통과…한국 영향은?" },
+  { press: "경향신문", title: "기후변화로 여름 더 길어졌다" },
+];
 
+function maskExtendedList(list) {
+  return [...list, list[0]];
+}
+
+export default function RollingArea() {
+  const extendedNewsList = maskExtendedList(newsList);
   const [index, setIndex] = useState(0);
+  const [isTransition, setIsTransition] = useState(true);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -62,15 +65,27 @@ export default function RollingArea() {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    if (index === extendedNewsList.length - 1) {
+      setTimeout(() => {
+        setIsTransition(false);
+        setIndex(0);
+      }, 500);
+      setTimeout(() => {
+        setIsTransition(true);
+      }, 510);
+    }
+  }, [index]);
+
   const getRollingStyle = {
     transform: `translateY(-${index * 49}px)`,
-    transition: "transform 0.5s ease-in-out",
+    transition: isTransition ? "transform 0.5s ease-in-out" : "none",
   };
   return (
     <RollingContainer>
       <RollingBox>
         <RollingList style={getRollingStyle}>
-          {newsList.map((news, i) => (
+          {extendedNewsList.map((news, i) => (
             <RollingItem key={i}>
               <PressName>{news.press}</PressName>
               <PressNewsTitle as="a">{news.title}</PressNewsTitle>
@@ -80,7 +95,7 @@ export default function RollingArea() {
       </RollingBox>
       <RollingBox>
         <RollingList style={getRollingStyle}>
-          {newsList.map((news, i) => (
+          {extendedNewsList.map((news, i) => (
             <RollingItem key={i}>
               <PressName>{news.press}</PressName>
               <PressNewsTitle as="a">{news.title}</PressNewsTitle>

--- a/src/components/rollingArea/RollingArea.jsx
+++ b/src/components/rollingArea/RollingArea.jsx
@@ -1,5 +1,5 @@
-// 필요한 리액트 훅과 styled-components import
 import styled from "styled-components";
+import { useState, useEffect } from "react";
 
 const RollingContainer = styled.div`
   margin-top: 40px;
@@ -19,7 +19,9 @@ const RollingBox = styled.div`
   overflow: hidden;
 `;
 
-const RollingTitle = styled.div`
+const RollingList = styled.div``;
+
+const RollingItem = styled.div`
   display: flex;
   gap: 16px;
   padding: 16px;
@@ -50,23 +52,41 @@ export default function RollingArea() {
     { press: "경향신문", title: "기후변화로 여름 더 길어졌다" },
   ];
 
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex((pre) => pre + 1);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const getRollingStyle = {
+    transform: `translateY(-${index * 49}px)`,
+    transition: "transform 0.5s ease-in-out",
+  };
   return (
     <RollingContainer>
       <RollingBox>
-        {newsList.map((news, i) => (
-          <RollingTitle key={i}>
-            <PressName>{news.press}</PressName>
-            <PressNewsTitle as="a">{news.title}</PressNewsTitle>
-          </RollingTitle>
-        ))}
+        <RollingList style={getRollingStyle}>
+          {newsList.map((news, i) => (
+            <RollingItem key={i}>
+              <PressName>{news.press}</PressName>
+              <PressNewsTitle as="a">{news.title}</PressNewsTitle>
+            </RollingItem>
+          ))}
+        </RollingList>
       </RollingBox>
       <RollingBox>
-        {newsList.map((news, i) => (
-          <RollingTitle key={i}>
-            <PressName>{news.press}</PressName>
-            <PressNewsTitle as="a">{news.title}</PressNewsTitle>
-          </RollingTitle>
-        ))}
+        <RollingList style={getRollingStyle}>
+          {newsList.map((news, i) => (
+            <RollingItem key={i}>
+              <PressName>{news.press}</PressName>
+              <PressNewsTitle as="a">{news.title}</PressNewsTitle>
+            </RollingItem>
+          ))}
+        </RollingList>
       </RollingBox>
     </RollingContainer>
   );

--- a/src/components/rollingArea/RollingArea.jsx
+++ b/src/components/rollingArea/RollingArea.jsx
@@ -56,7 +56,6 @@ function useRolling(newsList) {
   const extendedNewsList = maskExtendedList(newsList);
   const [index, setIndex] = useState(0);
   const [isTransition, setIsTransition] = useState(true);
-  const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -70,20 +69,21 @@ function useRolling(newsList) {
     if (index === extendedNewsList.length - 1) {
       setTimeout(() => {
         setIsTransition(false);
-        setIsVisible(false);
-        setIndex(0);
+
+        requestAnimationFrame(() => {
+          setIndex(0);
+
+          requestAnimationFrame(() => {
+            setIsTransition(true);
+          });
+        });
       }, 500);
-      setTimeout(() => {
-        setIsTransition(true);
-        setIsVisible(true);
-      }, 510);
     }
   }, [index]);
 
   const getRollingStyle = {
     transform: `translateY(-${index * 49}px)`,
     transition: isTransition ? "transform 0.5s ease-in-out" : "none",
-    opacity: isVisible ? 1 : 0,
   };
 
   return { list: extendedNewsList, getRollingStyle };

--- a/src/components/rollingArea/RollingArea.jsx
+++ b/src/components/rollingArea/RollingArea.jsx
@@ -52,10 +52,11 @@ function maskExtendedList(list) {
   return [...list, list[0]];
 }
 
-export default function RollingArea() {
+function useRolling(newsList) {
   const extendedNewsList = maskExtendedList(newsList);
   const [index, setIndex] = useState(0);
   const [isTransition, setIsTransition] = useState(true);
+  const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -69,10 +70,12 @@ export default function RollingArea() {
     if (index === extendedNewsList.length - 1) {
       setTimeout(() => {
         setIsTransition(false);
+        setIsVisible(false);
         setIndex(0);
       }, 500);
       setTimeout(() => {
         setIsTransition(true);
+        setIsVisible(true);
       }, 510);
     }
   }, [index]);
@@ -80,12 +83,20 @@ export default function RollingArea() {
   const getRollingStyle = {
     transform: `translateY(-${index * 49}px)`,
     transition: isTransition ? "transform 0.5s ease-in-out" : "none",
+    opacity: isVisible ? 1 : 0,
   };
+
+  return { list: extendedNewsList, getRollingStyle };
+}
+
+export default function RollingArea() {
+  const rollingList1 = useRolling(newsList);
+  const rollingList2 = useRolling(newsList);
   return (
     <RollingContainer>
       <RollingBox>
-        <RollingList style={getRollingStyle}>
-          {extendedNewsList.map((news, i) => (
+        <RollingList style={rollingList1.getRollingStyle}>
+          {rollingList1.list.map((news, i) => (
             <RollingItem key={i}>
               <PressName>{news.press}</PressName>
               <PressNewsTitle as="a">{news.title}</PressNewsTitle>
@@ -94,8 +105,8 @@ export default function RollingArea() {
         </RollingList>
       </RollingBox>
       <RollingBox>
-        <RollingList style={getRollingStyle}>
-          {extendedNewsList.map((news, i) => (
+        <RollingList style={rollingList2.getRollingStyle}>
+          {rollingList2.list.map((news, i) => (
             <RollingItem key={i}>
               <PressName>{news.press}</PressName>
               <PressNewsTitle as="a">{news.title}</PressNewsTitle>

--- a/src/components/rollingArea/RollingArea.jsx
+++ b/src/components/rollingArea/RollingArea.jsx
@@ -1,22 +1,29 @@
+// 필요한 리액트 훅과 styled-components import
 import styled from "styled-components";
 
-const Container = styled.div`
+const RollingContainer = styled.div`
   margin-top: 40px;
-  width: 930px;
   display: flex;
-  flex-direction: row;
-  justify-content: center;
   gap: 8px;
 `;
 
 const RollingBox = styled.div`
+  width: 461px;
+  height: 49px;
   background-color: var(--surface-alt);
-  padding: 16px;
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
   gap: 16px;
   border: 1px solid var(--border-default);
+  box-sizing: border-box;
+  overflow: hidden;
+`;
+
+const RollingTitle = styled.div`
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  align-items: center;
 `;
 
 const PressName = styled.div`
@@ -24,7 +31,7 @@ const PressName = styled.div`
   color: var(--text-strong);
 `;
 
-const Headline = styled.div`
+const PressNewsTitle = styled.div`
   width: 362px;
   font: var(--available-medium14);
   color: var(--text-default);
@@ -34,23 +41,33 @@ const Headline = styled.div`
   }
 `;
 
-function RollingArea() {
+export default function RollingArea() {
+  const newsList = [
+    { press: "연합뉴스", title: "[1보] 김기현·안철수 본경선 진출" },
+    { press: "중앙일보", title: "[속보] 삼성전자 1분기 실적 발표" },
+    { press: "한겨레", title: "서울시, 청년 월세 지원 대상 확대" },
+    { press: "조선일보", title: "美 반도체 법안 통과…한국 영향은?" },
+    { press: "경향신문", title: "기후변화로 여름 더 길어졌다" },
+  ];
+
   return (
-    <Container>
+    <RollingContainer>
       <RollingBox>
-        <PressName>연합뉴스</PressName>
-        <Headline as="a">
-          [1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출
-        </Headline>
+        {newsList.map((news, i) => (
+          <RollingTitle key={i}>
+            <PressName>{news.press}</PressName>
+            <PressNewsTitle as="a">{news.title}</PressNewsTitle>
+          </RollingTitle>
+        ))}
       </RollingBox>
       <RollingBox>
-        <PressName>연합뉴스</PressName>
-        <Headline as="a">
-          [속보] 與최고위원 본경선, 김병민·김용태·김재원·민영삼
-        </Headline>
+        {newsList.map((news, i) => (
+          <RollingTitle key={i}>
+            <PressName>{news.press}</PressName>
+            <PressNewsTitle as="a">{news.title}</PressNewsTitle>
+          </RollingTitle>
+        ))}
       </RollingBox>
-    </Container>
+    </RollingContainer>
   );
 }
-
-export default RollingArea;


### PR DESCRIPTION
### [전체를 다 보려 하지 말고 하나씩 접근해보기]
1. 정적인 뉴스 리스트 자동 롤링 두 영역 표시하기(롤링없이, 하나의 뉴스 타이틀 제외하고 `overflow : hidden` 으로 숨겨서)
2. 하나의 롤링 박스를 위로 올리기 뉴스 타이틀 하나하나 마다 5초씩 정지 후 다음 뉴스 타이틀이 보이게 처리
3. 무한 롤링 되도록 리스트 이어지게 처리하기
4. 두 번째 롤링 영역 1초 지연시켜 롤링 시키기 
5. 마우스 올렸을 때, 롤링 정지 해당하는 뉴스 타이틀 밑줄 표시 
6. 마우스 나갈 때, 다시 1초 간격을 두고 롤링 재 시작  

## 완료 작업 목록
- 미완성 
- 위의 접근 순서 1번 완료

## 주요 고민과 해결과정
- 고민 : 
&rarr; 뉴스 타이틀 하나하나마다 정지시켜 5초를 머무르게 할 것인가?
&rarr; onMouseEnter, onMouseLeave를 사용할때 상태처리를 어떻게 할 것인가?
&rarr; useState처리는 어느 부분을 해야할 것인가?
&rarr; 1초의 간격을 어떻게 둘 것인가?
&rarr; 마지막 뉴스 타이틀에서 처음 타이틀로 어떻게 자연스럽게 연결시킬 것인가?


